### PR TITLE
Use dp for max score

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 CC ?= cc
 
 ifeq "$(CC)" "clang"
-	CFLAGS := -Wall -Wextra -Wno-string-concatenation -pedantic -std=c99 -O3
+	CFLAGS := -Wall -Wextra -Wno-string-concatenation -pedantic -std=c99 -O3 -lm
 else
-	CFLAGS := -Wall -Wextra -Wunused-variable -Wno-stringop-truncation -pedantic -std=c99 -O3
+	CFLAGS := -Wall -Wextra -Wunused-variable -Wno-stringop-truncation -pedantic -std=c99 -O3 -lm
 endif
 
 programs=pool testpool benchmark scoredetail

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ else
 fi
 
 rm -rf pool testpool benchmark scoredetail
-${CC} ${CFLAGS} -o pool pool.c
-${CC} ${CFLAGS} -o testpool testpool.c
-${CC} ${CFLAGS} -o benchmark benchmark.c
-${CC} ${CFLAGS} -o scoredetail scoredetail.c
+${CC} ${CFLAGS} -lm -o pool pool.c
+${CC} ${CFLAGS} -lm -o testpool testpool.c
+${CC} ${CFLAGS} -lm -o benchmark benchmark.c
+${CC} ${CFLAGS} -lm -o scoredetail scoredetail.c

--- a/pool.c
+++ b/pool.c
@@ -154,7 +154,12 @@ void help(void) {
 "    greater than the loser’s seed. This differs from SeedDiff in that\n"
 "    the loser in the game need not have been picked correctly.\n"
 "5.  JoshP: each correct pick is worth the round multiplier for the\n"
-"    game’s round multiplied by the seed number of the winning team.\n"
+"    game's round multiplied by the seed number of the winning team.\n"
+"6.  UpsetMultiplier: each correct pick is worth the round multiplier\n"
+"    for the game's round multiplied by the winner's seed divided by\n"
+"    the loser's seed when the winner's seed is greater (an upset).\n"
+"    Otherwise it is worth just the round multiplier. The actual\n"
+"    opponent is used, like RelaxedSeedDiff.\n"
 "\n"
   );
   /* END HELP */

--- a/pool.h
+++ b/pool.h
@@ -168,7 +168,7 @@ typedef struct {
 #define POOL_RESULTS_FILE_NAME "results.txt"
 #define POOL_ENTRIES_DIR_NAME "entries"
 
-typedef enum { PoolScorerBasic = 0,  PoolScorerUpset, PoolScorerJoshP, PoolScorerSeedDiff, PoolScorerRelaxedSeedDiff } PoolScorerType;
+typedef enum { PoolScorerBasic = 0,  PoolScorerUpset, PoolScorerJoshP, PoolScorerSeedDiff, PoolScorerRelaxedSeedDiff, PoolScorerUpsetMultiplier } PoolScorerType;
 typedef enum { PoolFormatInvalid = 0, PoolFormatText, PoolFormatJson, PoolFormatBin } PoolReportFormat;
 
 POOLDEF void pool_defaults(void);
@@ -194,13 +194,14 @@ POOLDEF uint8_t pool_read_entry_to_bracket(const char *filePath, const char *ent
 POOLDEF void pool_bracket_score(PoolBracket *bracket, PoolBracket *results);
 POOLDEF uint8_t pool_round_of_game(uint8_t gameNum);
 POOLDEF void pool_teams_of_game(uint8_t gameNum, uint8_t round, PoolBracket *bracket, uint8_t *team1, uint8_t *team2);
-typedef uint32_t (*PoolScorerFunction)(PoolBracket *bracket, PoolBracket *results, uint8_t round, uint8_t game);
-POOLDEF uint32_t pool_basic_scorer(PoolBracket *bracket, PoolBracket *results, uint8_t round, uint8_t game);
-POOLDEF uint32_t pool_upset_scorer(PoolBracket *bracket, PoolBracket *results, uint8_t round, uint8_t game);
-POOLDEF uint32_t pool_josh_p_scorer(PoolBracket *bracket, PoolBracket *results, uint8_t round, uint8_t game);
-POOLDEF uint32_t pool_seed_diff_scorer(PoolBracket *bracket, PoolBracket *results, uint8_t round, uint8_t game);
-POOLDEF uint32_t pool_relaxed_seed_diff_scorer(PoolBracket *bracket, PoolBracket *results, uint8_t round, uint8_t game);
-POOLDEF uint32_t pool_dp_relaxed_max_score(PoolBracket *bracket, PoolBracket *results);
+typedef uint32_t (*PoolScorerFunction)(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game);
+POOLDEF uint32_t pool_basic_scorer(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game);
+POOLDEF uint32_t pool_upset_scorer(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game);
+POOLDEF uint32_t pool_josh_p_scorer(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game);
+POOLDEF uint32_t pool_seed_diff_scorer(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game);
+POOLDEF uint32_t pool_relaxed_seed_diff_scorer(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game);
+POOLDEF uint32_t pool_upset_multiplier_scorer(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game);
+POOLDEF uint32_t pool_dp_max_score(PoolBracket *bracket, PoolBracket *results);
 POOLDEF PoolScorerFunction pool_get_scorer_function(PoolScorerType scorerType);
 POOLDEF uint8_t pool_loser_of_game(uint8_t gameNum, PoolBracket *bracket);
 POOLDEF void pool_print_humanized(FILE *f_stream, uint64_t num, int fieldLength);
@@ -352,85 +353,42 @@ POOLDEF uint8_t pool_loser_of_game(uint8_t gameNum, PoolBracket *bracket) {
   return bracket->winners[prevGame1] == winner ? 
     bracket->winners[prevGame2] : bracket->winners[prevGame1];
 }
-POOLDEF uint32_t pool_basic_scorer(PoolBracket *bracket, PoolBracket *results, uint8_t round, uint8_t game) {
-  UNUSED(bracket);
-  UNUSED(results);
-  UNUSED(game);
+POOLDEF uint32_t pool_basic_scorer(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game) {
+  UNUSED(loser);
+  if (bracket->winners[game] != winner) return 0;
   return poolConfiguration.roundScores[round];
 }
-POOLDEF uint32_t pool_seed_diff_scorer(PoolBracket *bracket, PoolBracket *results, uint8_t round, uint8_t game) {
-  uint8_t resultsLoser = pool_loser_of_game(game, results);
+POOLDEF uint32_t pool_seed_diff_scorer(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game) {
+  if (bracket->winners[game] != winner) return 0;
   uint8_t bracketLoser = pool_loser_of_game(game, bracket);
   uint8_t bonus = 0;
-  if ( (resultsLoser == 0 && bracketLoser != 0 && !poolTeams[bracketLoser-1].eliminated) || resultsLoser == bracketLoser) {
-    PoolTeam *losingTeam = &poolTeams[bracketLoser-1];
-    uint8_t winner = bracket->winners[game];
-    PoolTeam *winningTeam = &poolTeams[winner-1];
-    bonus = winningTeam->seed > losingTeam->seed ? winningTeam->seed - losingTeam->seed : 0;
+  if (bracketLoser == loser) {
+    uint8_t wSeed = poolTeams[winner - 1].seed;
+    uint8_t lSeed = poolTeams[loser - 1].seed;
+    bonus = wSeed > lSeed ? wSeed - lSeed : 0;
   }
   return poolConfiguration.roundScores[round] + bonus;
 }
-// Returns the minimum seed among non-eliminated teams that could still
-// reach this game slot. For played games, only the winner remains.
-// For unplayed games, recursively checks both feeder game subtrees.
-// This is still not exact, however, as it overstates the maximum score since
-// you can get the seed bonus for picks against the same team more than one
-// time. Not sure how to solve this problem
-POOLDEF uint8_t pool_min_seed_reaching_game(uint8_t gameNum, PoolBracket *results) {
-  if (results->winners[gameNum] != 0) {
-    return poolTeams[results->winners[gameNum] - 1].seed;
-  }
-  uint8_t round = pool_round_of_game(gameNum);
-  if (round == 0) {
-    uint8_t team1 = gameNum * 2 + 1;
-    uint8_t team2 = team1 + 1;
-    uint8_t min = UINT8_MAX;
-    if (!poolTeams[team1 - 1].eliminated) min = poolTeams[team1 - 1].seed;
-    if (!poolTeams[team2 - 1].eliminated && poolTeams[team2 - 1].seed < min)
-      min = poolTeams[team2 - 1].seed;
-    return min;
-  }
-  uint8_t gameBase = round == 1 ? 0 : poolGamesInRound[round - 2];
-  uint8_t prevGame1 = gameBase + (gameNum - poolGamesInRound[round - 1]) * 2;
-  uint8_t prevGame2 = prevGame1 + 1;
-  uint8_t min1 = pool_min_seed_reaching_game(prevGame1, results);
-  uint8_t min2 = pool_min_seed_reaching_game(prevGame2, results);
-  return min1 < min2 ? min1 : min2;
-}
-POOLDEF uint32_t pool_relaxed_seed_diff_scorer(PoolBracket *bracket, PoolBracket *results, uint8_t round, uint8_t game) {
-  uint8_t winner = bracket->winners[game];
-  PoolTeam *winningTeam = &poolTeams[winner - 1];
-  uint8_t loser = pool_loser_of_game(game, results);
-  if (loser == 0) {
-    // Game not yet played — find min seed on the opponent's side of the bracket
-    uint8_t minSeed;
-    if (round == 0) {
-      uint8_t team1 = game * 2 + 1;
-      uint8_t team2 = team1 + 1;
-      uint8_t opponent = (team1 == winner) ? team2 : team1;
-      minSeed = poolTeams[opponent - 1].seed;
-    } else {
-      uint8_t gameBase = round == 1 ? 0 : poolGamesInRound[round - 2];
-      uint8_t prevGame1 = gameBase + (game - poolGamesInRound[round - 1]) * 2;
-      uint8_t prevGame2 = prevGame1 + 1;
-      // Winner came through one feeder game; opponent comes from the other
-      uint8_t opponentGame = (bracket->winners[prevGame1] == winner) ? prevGame2 : prevGame1;
-      minSeed = pool_min_seed_reaching_game(opponentGame, results);
-    }
-    if (minSeed == UINT8_MAX) return poolConfiguration.roundScores[round];
-    uint32_t bonus = winningTeam->seed > minSeed ? winningTeam->seed - minSeed : 0;
-    return poolConfiguration.roundScores[round] + bonus;
-  }
-  PoolTeam *losingTeam = &poolTeams[loser - 1];
-  uint32_t bonus = winningTeam->seed > losingTeam->seed ? winningTeam->seed - losingTeam->seed : 0;
+POOLDEF uint32_t pool_relaxed_seed_diff_scorer(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game) {
+  if (bracket->winners[game] != winner) return 0;
+  uint8_t wSeed = poolTeams[winner - 1].seed;
+  uint8_t lSeed = poolTeams[loser - 1].seed;
+  uint32_t bonus = wSeed > lSeed ? wSeed - lSeed : 0;
   return poolConfiguration.roundScores[round] + bonus;
 }
-// Computes exact max possible score using tree DP, avoiding the double-counting
-// issue in pool_relaxed_seed_diff_scorer where the same low-seeded team can be
-// "used" as the ideal opponent in multiple games simultaneously.
+POOLDEF uint32_t pool_upset_multiplier_scorer(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game) {
+  if (bracket->winners[game] != winner) return 0;
+  uint8_t wSeed = poolTeams[winner - 1].seed;
+  uint8_t lSeed = poolTeams[loser - 1].seed;
+  if (wSeed > lSeed) {
+    return poolConfiguration.roundScores[round] * wSeed / lSeed;
+  }
+  return poolConfiguration.roundScores[round];
+}
+// Computes exact max possible score using tree DP.
 // dp[game][team] = max total bracket score from all games in this subtree,
 // if team emerges as winner of game. UINT32_MAX = impossible.
-POOLDEF uint32_t pool_dp_relaxed_max_score(PoolBracket *bracket, PoolBracket *results) {
+POOLDEF uint32_t pool_dp_max_score(PoolBracket *bracket, PoolBracket *results) {
   uint32_t dp[POOL_NUM_GAMES][POOL_NUM_TEAMS];
   memset(dp, 0xFF, sizeof(dp));
 
@@ -445,31 +403,13 @@ POOLDEF uint32_t pool_dp_relaxed_max_score(PoolBracket *bracket, PoolBracket *re
       if (results->winners[g] != 0) {
         uint8_t winner = results->winners[g];
         uint8_t loser = (winner == team1) ? team2 : team1;
-        uint32_t gameScore = 0;
-        if (bracket->winners[g] == winner) {
-          uint8_t wSeed = poolTeams[winner - 1].seed;
-          uint8_t lSeed = poolTeams[loser - 1].seed;
-          gameScore = poolConfiguration.roundScores[0] + (wSeed > lSeed ? wSeed - lSeed : 0);
-        }
-        dp[g][winner - 1] = gameScore;
+        dp[g][winner - 1] = (*poolConfiguration.poolScorer)(bracket, winner, loser, 0, g);
       } else {
         if (!poolTeams[team1 - 1].eliminated) {
-          uint32_t gameScore = 0;
-          if (bracket->winners[g] == team1) {
-            uint8_t wSeed = poolTeams[team1 - 1].seed;
-            uint8_t lSeed = poolTeams[team2 - 1].seed;
-            gameScore = poolConfiguration.roundScores[0] + (wSeed > lSeed ? wSeed - lSeed : 0);
-          }
-          dp[g][team1 - 1] = gameScore;
+          dp[g][team1 - 1] = (*poolConfiguration.poolScorer)(bracket, team1, team2, 0, g);
         }
         if (!poolTeams[team2 - 1].eliminated) {
-          uint32_t gameScore = 0;
-          if (bracket->winners[g] == team2) {
-            uint8_t wSeed = poolTeams[team2 - 1].seed;
-            uint8_t lSeed = poolTeams[team1 - 1].seed;
-            gameScore = poolConfiguration.roundScores[0] + (wSeed > lSeed ? wSeed - lSeed : 0);
-          }
-          dp[g][team2 - 1] = gameScore;
+          dp[g][team2 - 1] = (*poolConfiguration.poolScorer)(bracket, team2, team1, 0, g);
         }
       }
     } else {
@@ -488,12 +428,7 @@ POOLDEF uint32_t pool_dp_relaxed_max_score(PoolBracket *bracket, PoolBracket *re
           dpW = dp[prevGame2][winner - 1];
           dpL = dp[prevGame1][loser - 1];
         }
-        uint32_t gameScore = 0;
-        if (bracket->winners[g] == winner) {
-          uint8_t wSeed = poolTeams[winner - 1].seed;
-          uint8_t lSeed = poolTeams[loser - 1].seed;
-          gameScore = poolConfiguration.roundScores[round] + (wSeed > lSeed ? wSeed - lSeed : 0);
-        }
+        uint32_t gameScore = (*poolConfiguration.poolScorer)(bracket, winner, loser, round, g);
         dp[g][winner - 1] = dpW + dpL + gameScore;
       } else {
         for (uint8_t tl = 0; tl < POOL_NUM_TEAMS; tl++) {
@@ -504,12 +439,7 @@ POOLDEF uint32_t pool_dp_relaxed_max_score(PoolBracket *bracket, PoolBracket *re
 
             // TL wins game g
             {
-              uint32_t gameScore = 0;
-              if (bracket->winners[g] == tl + 1) {
-                uint8_t wSeed = poolTeams[tl].seed;
-                uint8_t lSeed = poolTeams[tr].seed;
-                gameScore = poolConfiguration.roundScores[round] + (wSeed > lSeed ? wSeed - lSeed : 0);
-              }
+              uint32_t gameScore = (*poolConfiguration.poolScorer)(bracket, tl + 1, tr + 1, round, g);
               uint32_t candidate = subtreeScore + gameScore;
               if (dp[g][tl] == UINT32_MAX || candidate > dp[g][tl]) {
                 dp[g][tl] = candidate;
@@ -518,12 +448,7 @@ POOLDEF uint32_t pool_dp_relaxed_max_score(PoolBracket *bracket, PoolBracket *re
 
             // TR wins game g
             {
-              uint32_t gameScore = 0;
-              if (bracket->winners[g] == tr + 1) {
-                uint8_t wSeed = poolTeams[tr].seed;
-                uint8_t lSeed = poolTeams[tl].seed;
-                gameScore = poolConfiguration.roundScores[round] + (wSeed > lSeed ? wSeed - lSeed : 0);
-              }
+              uint32_t gameScore = (*poolConfiguration.poolScorer)(bracket, tr + 1, tl + 1, round, g);
               uint32_t candidate = subtreeScore + gameScore;
               if (dp[g][tr] == UINT32_MAX || candidate > dp[g][tr]) {
                 dp[g][tr] = candidate;
@@ -543,17 +468,15 @@ POOLDEF uint32_t pool_dp_relaxed_max_score(PoolBracket *bracket, PoolBracket *re
   }
   return maxScore;
 }
-POOLDEF uint32_t pool_josh_p_scorer(PoolBracket *bracket, PoolBracket *results, uint8_t round, uint8_t game) {
-  UNUSED(results);
-  uint8_t winner = bracket->winners[game];
-  PoolTeam *winningTeam = &poolTeams[winner-1];
-  return poolConfiguration.roundScores[round] * winningTeam->seed;
+POOLDEF uint32_t pool_josh_p_scorer(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game) {
+  UNUSED(loser);
+  if (bracket->winners[game] != winner) return 0;
+  return poolConfiguration.roundScores[round] * poolTeams[winner - 1].seed;
 }
-POOLDEF uint32_t pool_upset_scorer(PoolBracket *bracket, PoolBracket *results, uint8_t round, uint8_t game) {
-  UNUSED(results);
-  uint8_t winner = bracket->winners[game];
-  PoolTeam *winningTeam = &poolTeams[winner-1];
-  return poolConfiguration.roundScores[round] + winningTeam->seed;
+POOLDEF uint32_t pool_upset_scorer(PoolBracket *bracket, uint8_t winner, uint8_t loser, uint8_t round, uint8_t game) {
+  UNUSED(loser);
+  if (bracket->winners[game] != winner) return 0;
+  return poolConfiguration.roundScores[round] + poolTeams[winner - 1].seed;
 }
 POOLDEF PoolScorerFunction pool_get_scorer_function(PoolScorerType scorerType) {
   switch(scorerType) {
@@ -572,6 +495,9 @@ POOLDEF PoolScorerFunction pool_get_scorer_function(PoolScorerType scorerType) {
     case PoolScorerRelaxedSeedDiff:
       return &pool_relaxed_seed_diff_scorer;
       break;
+    case PoolScorerUpsetMultiplier:
+      return &pool_upset_multiplier_scorer;
+      break;
     default:
       fprintf(stderr, "Error, unknown PoolScorerType: %d\n", scorerType);
       exit(1);
@@ -584,7 +510,6 @@ POOLDEF uint8_t pool_round_of_game(uint8_t gameNum) {
 
 POOLDEF void pool_bracket_score(PoolBracket *bracket, PoolBracket *results) {
   bracket->score = 0;
-  bracket->maxScore = 0;
   bracket->roundScores[0] = 0;
   bracket->wins = 0;
   uint8_t round = 0;
@@ -593,25 +518,19 @@ POOLDEF void pool_bracket_score(PoolBracket *bracket, PoolBracket *results) {
       round++;
       bracket->roundScores[round] = 0;
     }
-    uint8_t bracketWinner = bracket->winners[g];
     uint8_t resultsWinner = results->winners[g];
-    if (resultsWinner != 0) {
-      if (bracketWinner == resultsWinner) {
-        uint32_t gameScore = (*poolConfiguration.poolScorer)(bracket, results, round, g);
-        bracket->score += gameScore;
-        bracket->maxScore += gameScore;
-        bracket->roundScores[round] += gameScore;
-        bracket->wins += 1;
-      }
-    } else {
-      if (!poolTeams[bracketWinner - 1].eliminated) {
-        uint32_t gameScore = (*poolConfiguration.poolScorer)(bracket, results, round, g);
-        bracket->maxScore += gameScore;
-      }
+    if (resultsWinner != 0 && bracket->winners[g] == resultsWinner) {
+      uint8_t loser = pool_loser_of_game(g, results);
+      uint32_t gameScore = (*poolConfiguration.poolScorer)(bracket, resultsWinner, loser, round, g);
+      bracket->score += gameScore;
+      bracket->roundScores[round] += gameScore;
+      bracket->wins += 1;
     }
   }
-  if (poolConfiguration.scorerType == PoolScorerRelaxedSeedDiff) {
-    bracket->maxScore = pool_dp_relaxed_max_score(bracket, results);
+  if (pool_games_played() < POOL_NUM_GAMES) {
+    bracket->maxScore = pool_dp_max_score(bracket, results);
+  } else {
+    bracket->maxScore = bracket->score;
   }
   if (results->tieBreak > 0) {
     bracket->tieBreakDiff = abs(results->tieBreak - bracket->tieBreak);
@@ -937,10 +856,7 @@ POOLDEF void pool_possibilities_dfs(
     uint8_t otherTeam = teams[1-t];
     poolTeams[otherTeam-1].eliminated = true;
     for (size_t i = 0; i < numBrackets; i++) {
-      bracketGameScores[i] = 0;
-      if (teams[t] == stats[i].bracket->winners[gameNum]) {
-        bracketGameScores[i] = (*poolConfiguration.poolScorer)(stats[i].bracket, possibleBracket, round, gameNum);
-      }
+      bracketGameScores[i] = (*poolConfiguration.poolScorer)(stats[i].bracket, teams[t], otherTeam, round, gameNum);
       stats[i].possibleScore += bracketGameScores[i];
     }
     
@@ -1634,14 +1550,16 @@ POOLDEF void pool_read_config_file(const char *filePath) {
     if (strncmp(line, "scorerType=", 11) == 0) {
       if (strncmp(line+11, "Basic", 5) == 0) {
         // do nothing, default is basic
+      } else if (strncmp(line+11, "UpsetMultiplier", 15) == 0) {
+        poolConfiguration.scorerType = PoolScorerUpsetMultiplier;
       } else if (strncmp(line+11, "Upset", 5) == 0) {
         poolConfiguration.scorerType = PoolScorerUpset;
       } else if (strncmp(line+11, "JoshP", 5) == 0) {
         poolConfiguration.scorerType = PoolScorerJoshP;
-      } else if (strncmp(line+11, "SeedDiff", 8) == 0) {
-        poolConfiguration.scorerType = PoolScorerSeedDiff;
       } else if (strncmp(line+11, "RelaxedSeedDiff", 15) == 0) {
         poolConfiguration.scorerType = PoolScorerRelaxedSeedDiff;
+      } else if (strncmp(line+11, "SeedDiff", 8) == 0) {
+        poolConfiguration.scorerType = PoolScorerSeedDiff;
       } else {
         fprintf(stderr, "config.txt scorerType %s is not known\n", line+11);
         exit(1);

--- a/pool.h
+++ b/pool.h
@@ -14,6 +14,7 @@
 #include <assert.h>
 #include <inttypes.h>
 #include <time.h>
+#include <math.h>
 
 #ifndef POOLDEF
 #define POOLDEF static inline
@@ -381,7 +382,7 @@ POOLDEF uint32_t pool_upset_multiplier_scorer(PoolBracket *bracket, uint8_t winn
   uint8_t wSeed = poolTeams[winner - 1].seed;
   uint8_t lSeed = poolTeams[loser - 1].seed;
   if (wSeed > lSeed) {
-    return poolConfiguration.roundScores[round] * wSeed / lSeed;
+    return ceilf(poolConfiguration.roundScores[round] * 1.0 * wSeed / lSeed);
   }
   return poolConfiguration.roundScores[round];
 }
@@ -390,7 +391,7 @@ POOLDEF uint32_t pool_upset_multiplier_scorer(PoolBracket *bracket, uint8_t winn
 // if team emerges as winner of game. UINT32_MAX = impossible.
 POOLDEF uint32_t pool_dp_max_score(PoolBracket *bracket, PoolBracket *results) {
   uint32_t dp[POOL_NUM_GAMES][POOL_NUM_TEAMS];
-  memset(dp, 0xFF, sizeof(dp));
+  memset(dp, 0XFF, sizeof(dp));
 
   uint8_t round = 0;
   for (uint8_t g = 0; g < POOL_NUM_GAMES; g++) {

--- a/scoredetail.c
+++ b/scoredetail.c
@@ -20,32 +20,16 @@ int main(void) {
   printf("Score: %d\n", entry.score);
   printf("Max Score: %d\n", entry.maxScore);
   uint32_t total = 0;
-  uint32_t maxScore = 0;
   for (uint8_t g = 0; g < POOL_NUM_GAMES; g++) {
     uint8_t team1 = 0;
     uint8_t team2 = 0;
     uint8_t round = pool_round_of_game(g);
-    pool_teams_of_game(g, round, &entry, &team1, &team2); 
+    pool_teams_of_game(g, round, &entry, &team1, &team2);
     uint32_t score = 0;
-    if (poolTournamentBracket.winners[g] != 0) {
-      if (entry.winners[g] == poolTournamentBracket.winners[g]) {
-        score = (*poolConfiguration.poolScorer)(&entry, &poolTournamentBracket, round, g);
-        maxScore += score;
-      }
-    } else {
-      if (!poolTeams[entry.winners[g] - 1].eliminated) {
-        maxScore += (*poolConfiguration.poolScorer)(&entry, &poolTournamentBracket, round, g);
-      }
+    if (poolTournamentBracket.winners[g] != 0 && entry.winners[g] == poolTournamentBracket.winners[g]) {
+      uint8_t loser = pool_loser_of_game(g, &poolTournamentBracket);
+      score = (*poolConfiguration.poolScorer)(&entry, poolTournamentBracket.winners[g], loser, round, g);
     }
-    /*
-    if (entry.winners[g] == poolTournamentBracket.winners[g]) {
-      score = (*poolConfiguration.poolScorer)(&entry, &poolTournamentBracket, round, g);
-    }
-    if (!poolTeams[entry.winners[g]-1].eliminated &&
-      (entry.winners[g] == poolTournamentBracket.winners[g] || poolTournamentBracket.winners[g] == 0)) {
-      maxScore += (*poolConfiguration.poolScorer)(&entry, &poolTournamentBracket, round, g);
-    }
-    */
     total += score;
     PoolTeam *t1 = team1 > 0 ? &poolTeams[team1-1] : NULL;
     PoolTeam *t2 = team2 > 0 ? &poolTeams[team2-1] : NULL;
@@ -55,9 +39,9 @@ int main(void) {
     printf(STRIKE(team2, poolTournamentBracket.winners[g], "%s"), POOL_TEAM_SHORT_NAME(team2));
     printf(" (%d) => ", t2 ? t2->seed : 0);
     printf(STRIKE(entry.winners[g], poolTournamentBracket.winners[g], "%s"), POOL_TEAM_SHORT_NAME(entry.winners[g]));
-    printf(" =? %s: score: %u/%u/%u\n",
+    printf(" =? %s: score: %u/%u\n",
            POOL_TEAM_SHORT_NAME(poolTournamentBracket.winners[g]),
-           score, total, maxScore);
+           score, total);
   }
   return 0;
 }

--- a/testpool.c
+++ b/testpool.c
@@ -25,8 +25,8 @@ int main(void) {
   pool_possibilities_report(PoolFormatText, true, 0, 1, false);
 
   // Advance pool to final four
-  time_t t;
-  srand((unsigned) time(&t));
+  srand(time(NULL));
+  rand();
   uint8_t gameNum = pool_games_played();
   size_t gamesRemaining = 63 - gameNum;
   while (gamesRemaining > 3) {


### PR DESCRIPTION
Fix the max score calculation for RelaxedSeedDiff by using a DP per bracket that calculates max score per winner of each game based on the previous game max score and bracket picks. Then use this for all scorers, even if not strictly necessary (when the score does not depend on actual loser). The only scorers where this is the case are RelaxedSeedDiff and the new UpsetMultiplier scorer