### PR TITLE
AWS Batch parallel possibilities report

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,11 +279,15 @@ pool directory, then generate the possibilities report:
 ./pool -d test/fifty_entries -r poss
 ```
 
-Using this method and a compute cloud of 8,192 machines, we can generate a possibilities
-report after Day 1 is complete in less than 1 hour. LOL.
+Using this method and a compute cloud of 4,096 Spot instances, we can generate a possibilities
+report after Day 1 is complete in about 4 hours at a cost of roughly $280. See `aws/` for a
+complete implementation using AWS Batch.
 
-On a single machine, the best you are going to be able to do is generate the report
-in less than 1 hour by running 8 processes once there are about 38 teams remaining.
+On a single machine, run one process per core using `parallel.sh` (set `PROCS` to your
+core count). At 2.3M nodes/sec per process, a 12-core machine can generate the report
+in under 1 hour once there are 36 games remaining (about 37 teams), taking roughly 41
+minutes. With fewer cores the threshold is lower — for N cores it is when
+2^(games remaining) / (N × 2,300,000) falls under 3,600 seconds.
 
 Game Index
 -----------

--- a/aws/Dockerfile
+++ b/aws/Dockerfile
@@ -1,0 +1,18 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+RUN dnf install -y gcc unzip && dnf clean all && \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/aws.zip && \
+    unzip -q /tmp/aws.zip -d /tmp && \
+    /tmp/aws/install && \
+    rm -rf /tmp/aws.zip /tmp/aws
+
+WORKDIR /build
+COPY pool.c pool.h ./
+RUN gcc -Wall -Wextra -Wunused-variable -Wno-stringop-truncation -pedantic -std=c99 -O3 \
+        -lm -o /usr/local/bin/pool pool.c
+
+WORKDIR /app
+COPY aws/worker.sh ./
+RUN chmod +x worker.sh
+
+ENTRYPOINT ["/app/worker.sh"]

--- a/aws/Gemfile
+++ b/aws/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'aws-sdk-s3'
+gem 'aws-sdk-batch'

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,0 +1,145 @@
+# AWS Parallel Possibilities Report
+
+Runs the `poss` report overnight after Day 1 of Round 1 using 4,096 AWS Batch
+Spot jobs. At that point 47 games remain (2^47 ≈ 140 trillion outcomes), which
+takes roughly 4 hours across 4,096 workers at ~2.3M DFS nodes/sec each.
+
+**Estimated cost: ~$280 on c6a Spot instances.**
+
+> **Warning:** This implementation is untested. The cost estimate is based on
+> back-of-the-envelope math and actual AWS Spot pricing at time of writing — your
+> mileage may vary. Verify the Terraform, IAM roles, and job definitions against
+> current AWS Batch documentation before running.
+
+For later rounds (≤36 games remaining), a 12-core local machine handles it in
+under an hour for free — skip this entirely and use `parallel.sh` instead.
+
+---
+
+## Prerequisites
+
+- AWS CLI configured with credentials (`aws configure`)
+- Terraform ≥ 1.0
+- Docker
+- Ruby with Bundler (`gem install bundler`)
+- `pool` binary built locally (`make`)
+
+The AWS credentials need permissions for: S3, ECR, Batch, and IAM (for
+`terraform apply`). A power-user or admin role works for the one-time setup.
+Day-to-day usage (submit + aggregate) only needs S3 and Batch access.
+
+---
+
+## One-Time Setup
+
+### 1. Provision infrastructure
+
+```console
+$ cd aws/infra
+$ terraform init
+$ terraform apply -var="bucket_name=my-tournament-pool"
+```
+
+Note the outputs — you'll need the ECR repository URL.
+
+> **vCPU limit:** AWS accounts default to 256–1,024 vCPUs for Batch. With 4,096
+> jobs each using 1 vCPU you will need a limit increase. Request it via the
+> Service Quotas console under *AWS Batch → EC2 vCPUs* before tournament day.
+
+### 2. Build and push the Docker image
+
+```console
+$ cd /path/to/tournament3
+
+$ aws ecr get-login-password --region us-east-1 \
+    | docker login --username AWS --password-stdin <ecr-repository-url>
+
+$ docker build -f aws/Dockerfile -t tournament-pool .
+$ docker tag tournament-pool:latest <ecr-repository-url>:latest
+$ docker push <ecr-repository-url>:latest
+```
+
+Rebuild and push the image any time `pool.c` or `pool.h` changes.
+
+### 3. Install Ruby dependencies
+
+```console
+$ cd aws
+$ bundle install
+```
+
+---
+
+## Each Year's Tournament
+
+### Night of Day 1 (after the last game finishes)
+
+Make sure `results.txt` is up to date with all 16 Day 1 winners, then submit:
+
+```console
+$ ruby aws/scripts/submit_jobs.rb -d 2025/ -b my-tournament-pool
+```
+
+This uploads your pool directory to S3 and submits a 4,096-job Batch array. It
+prints the job ID and the exact `aggregate.rb` command to run in the morning,
+then exits. Jobs run overnight unattended.
+
+Monitor progress in the AWS Batch console or:
+
+```console
+$ aws batch describe-jobs --jobs <job-id> \
+    --query 'jobs[0].{status:status,succeeded:arrayProperties.statusSummary.SUCCEEDED}'
+```
+
+### Morning (after all jobs show SUCCEEDED)
+
+```console
+$ ruby aws/scripts/aggregate.rb -b my-tournament-pool -d 2025/
+```
+
+This downloads all 4,096 `.bin` files from S3 in parallel (32 threads) into a
+temp directory, then runs `./pool -r poss` locally to produce the report.
+
+---
+
+## Reference
+
+### `submit_jobs.rb` options
+
+| Flag | Default | Description |
+|---|---|---|
+| `-d DIR` | *(required)* | Local pool directory to upload |
+| `-b BUCKET` | *(required)* | S3 bucket name |
+| `--prefix P` | `pool` | S3 key prefix |
+| `--queue Q` | `tournament-pool-queue` | Batch job queue |
+| `--job-def D` | `tournament-pool-worker` | Batch job definition |
+| `--region R` | `us-east-1` | AWS region |
+
+### `aggregate.rb` options
+
+| Flag | Default | Description |
+|---|---|---|
+| `-b BUCKET` | *(required)* | S3 bucket name |
+| `-d DIR` | *(required)* | Local pool directory (for teams/config/results) |
+| `--prefix P` | `pool` | S3 key prefix |
+| `--pool BIN` | `../../pool` | Path to pool binary |
+| `--region R` | `us-east-1` | AWS region |
+
+### S3 layout
+
+```
+s3://my-tournament-pool/
+  pool/
+    data/          ← uploaded by submit_jobs.rb
+      config.txt
+      teams.txt
+      results.txt
+      entries/
+        *.txt
+    bins/          ← written by workers, read by aggregate.rb
+      poss_0_of_4096.bin
+      poss_1_of_4096.bin
+      ...
+```
+
+Bin files expire automatically after 7 days (configured in Terraform).

--- a/aws/infra/main.tf
+++ b/aws/infra/main.tf
@@ -1,0 +1,208 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+# ── Networking (default VPC) ───────────────────────────────────────────────────
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "aws_security_group" "default" {
+  name   = "default"
+  vpc_id = data.aws_vpc.default.id
+}
+
+# ── S3 ────────────────────────────────────────────────────────────────────────
+
+resource "aws_s3_bucket" "pool" {
+  bucket        = var.bucket_name
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "pool" {
+  bucket = aws_s3_bucket.pool.id
+
+  rule {
+    id     = "expire-bins"
+    status = "Enabled"
+    filter { prefix = "pool/bins/" }
+    expiration { days = 7 }
+  }
+}
+
+# ── ECR ───────────────────────────────────────────────────────────────────────
+
+resource "aws_ecr_repository" "pool" {
+  name                 = "tournament-pool"
+  image_tag_mutability = "MUTABLE"
+}
+
+resource "aws_ecr_lifecycle_policy" "pool" {
+  repository = aws_ecr_repository.pool.name
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last 3 images"
+      selection    = { tagStatus = "any", countType = "imageCountMoreThan", countNumber = 3 }
+      action       = { type = "expire" }
+    }]
+  })
+}
+
+# ── IAM: Batch service role ────────────────────────────────────────────────────
+
+resource "aws_iam_role" "batch_service" {
+  name = "tournament-pool-batch-service"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "batch.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "batch_service" {
+  role       = aws_iam_role.batch_service.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+}
+
+# ── IAM: EC2 instance role (for ECS agent on Batch nodes) ─────────────────────
+
+resource "aws_iam_role" "batch_instance" {
+  name = "tournament-pool-batch-instance"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "batch_instance_ecs" {
+  role       = aws_iam_role.batch_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "batch_instance" {
+  name = "tournament-pool-batch-instance"
+  role = aws_iam_role.batch_instance.name
+}
+
+# ── IAM: Job role (container's S3 access) ─────────────────────────────────────
+
+resource "aws_iam_role" "batch_job" {
+  name = "tournament-pool-batch-job"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "batch_job_s3" {
+  name = "s3-pool-access"
+  role = aws_iam_role.batch_job.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:GetObject", "s3:PutObject", "s3:ListBucket"]
+      Resource = [aws_s3_bucket.pool.arn, "${aws_s3_bucket.pool.arn}/*"]
+    }]
+  })
+}
+
+# ── IAM: Spot fleet role ───────────────────────────────────────────────────────
+
+resource "aws_iam_role" "spot_fleet" {
+  name = "tournament-pool-spot-fleet"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "spotfleet.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "spot_fleet" {
+  role       = aws_iam_role.spot_fleet.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
+}
+
+# ── Batch compute environment ─────────────────────────────────────────────────
+# 4096 max vCPUs = 4096 x 1-vCPU jobs running concurrently.
+# Raise this limit via AWS Support if your account default is lower.
+
+resource "aws_batch_compute_environment" "pool" {
+  compute_environment_name = "tournament-pool"
+  type                     = "MANAGED"
+  service_role             = aws_iam_role.batch_service.arn
+
+  compute_resources {
+    type                = "SPOT"
+    bid_percentage      = 60
+    min_vcpus           = 0
+    max_vcpus           = 4096
+    instance_type       = ["c6a"]
+    subnets             = data.aws_subnets.default.ids
+    security_group_ids  = [data.aws_security_group.default.id]
+    instance_role       = aws_iam_instance_profile.batch_instance.arn
+    spot_iam_fleet_role = aws_iam_role.spot_fleet.arn
+  }
+}
+
+# ── Batch job queue ────────────────────────────────────────────────────────────
+
+resource "aws_batch_job_queue" "pool" {
+  name     = "tournament-pool-queue"
+  state    = "ENABLED"
+  priority = 1
+
+  compute_environment_order {
+    order               = 1
+    compute_environment = aws_batch_compute_environment.pool.arn
+  }
+}
+
+# ── Batch job definition ───────────────────────────────────────────────────────
+
+resource "aws_batch_job_definition" "worker" {
+  name = "tournament-pool-worker"
+  type = "container"
+
+  container_properties = jsonencode({
+    image      = "${aws_ecr_repository.pool.repository_url}:latest"
+    jobRoleArn = aws_iam_role.batch_job.arn
+    resourceRequirements = [
+      { type = "VCPU",   value = "1"   },
+      { type = "MEMORY", value = "512" }
+    ]
+    logConfiguration = { logDriver = "awslogs" }
+  })
+}

--- a/aws/infra/outputs.tf
+++ b/aws/infra/outputs.tf
@@ -1,0 +1,15 @@
+output "s3_bucket" {
+  value = aws_s3_bucket.pool.bucket
+}
+
+output "ecr_repository_url" {
+  value = aws_ecr_repository.pool.repository_url
+}
+
+output "job_queue" {
+  value = aws_batch_job_queue.pool.name
+}
+
+output "job_definition" {
+  value = aws_batch_job_definition.worker.name
+}

--- a/aws/infra/variables.tf
+++ b/aws/infra/variables.tf
@@ -1,0 +1,9 @@
+variable "region" {
+  description = "AWS region"
+  default     = "us-east-1"
+}
+
+variable "bucket_name" {
+  description = "S3 bucket for pool data and bin files"
+  type        = string
+}

--- a/aws/scripts/aggregate.rb
+++ b/aws/scripts/aggregate.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'aws-sdk-s3'
+require 'optparse'
+require 'pathname'
+require 'tmpdir'
+require 'fileutils'
+require 'thread'
+
+NUM_BATCHES      = 4096
+DOWNLOAD_THREADS = 32
+
+options = {
+  region:    'us-east-1',
+  s3_prefix: 'pool',
+  pool_bin:  File.expand_path('../../../pool', __dir__)
+}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: aggregate.rb -b BUCKET -d POOL_DIR [options]"
+  opts.on('-b BUCKET',   'S3 bucket name')                        { |v| options[:bucket]   = v }
+  opts.on('-d DIR',      'Local pool directory (config/teams/results)') { |v| options[:pool_dir] = v }
+  opts.on('--prefix P',  'S3 key prefix (default: pool)')         { |v| options[:s3_prefix] = v }
+  opts.on('--pool BIN',  'Path to pool binary')                   { |v| options[:pool_bin]  = v }
+  opts.on('--region R',  'AWS region (default: us-east-1)')       { |v| options[:region]    = v }
+end.parse!
+
+abort "S3 bucket required (-b)"      unless options[:bucket]
+abort "Pool directory required (-d)" unless options[:pool_dir]
+abort "pool binary not found at #{options[:pool_bin]} (build first with make, or pass --pool)" \
+  unless File.executable?(options[:pool_bin])
+
+pool_dir = Pathname.new(options[:pool_dir]).expand_path
+s3       = Aws::S3::Client.new(region: options[:region])
+bins_prefix = "#{options[:s3_prefix]}/bins"
+
+Dir.mktmpdir('pool-aggregate') do |tmpdir|
+  # Copy local pool data (teams, config, results, entries) into tmpdir
+  FileUtils.cp_r("#{pool_dir}/.", tmpdir)
+
+  # Parallel download of bin files from S3
+  puts "Downloading #{NUM_BATCHES} bin files from s3://#{options[:bucket]}/#{bins_prefix}/ ..."
+
+  queue     = Queue.new
+  NUM_BATCHES.times { |i| queue << i }
+
+  completed = 0
+  mutex     = Mutex.new
+
+  threads = DOWNLOAD_THREADS.times.map do
+    Thread.new do
+      client = Aws::S3::Client.new(region: options[:region])
+      while (i = queue.pop(true) rescue nil)
+        key   = "#{bins_prefix}/poss_#{i}_of_#{NUM_BATCHES}.bin"
+        local = File.join(tmpdir, "poss_#{i}_of_#{NUM_BATCHES}.bin")
+        client.get_object(response_target: local, bucket: options[:bucket], key: key)
+        mutex.synchronize do
+          completed += 1
+          print "\r  #{completed}/#{NUM_BATCHES}" if (completed % 100).zero? || completed == NUM_BATCHES
+        end
+      end
+    end
+  end
+  threads.each(&:join)
+  puts "\n  Done."
+
+  puts "\nRunning possibilities report..."
+  exec options[:pool_bin], '-d', tmpdir, '-r', 'poss'
+end

--- a/aws/scripts/submit_jobs.rb
+++ b/aws/scripts/submit_jobs.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'aws-sdk-s3'
+require 'aws-sdk-batch'
+require 'optparse'
+require 'pathname'
+
+NUM_BATCHES = 4096
+
+options = {
+  region:         'us-east-1',
+  s3_prefix:      'pool',
+  job_queue:      'tournament-pool-queue',
+  job_definition: 'tournament-pool-worker'
+}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: submit_jobs.rb -d POOL_DIR -b BUCKET [options]"
+  opts.on('-d DIR',        'Local pool directory to upload')         { |v| options[:pool_dir]       = v }
+  opts.on('-b BUCKET',     'S3 bucket name')                        { |v| options[:bucket]         = v }
+  opts.on('--prefix P',    'S3 key prefix (default: pool)')         { |v| options[:s3_prefix]      = v }
+  opts.on('--queue Q',     'Batch job queue name')                  { |v| options[:job_queue]      = v }
+  opts.on('--job-def D',   'Batch job definition name')             { |v| options[:job_definition] = v }
+  opts.on('--region R',    'AWS region (default: us-east-1)')       { |v| options[:region]         = v }
+end.parse!
+
+abort "Pool directory required (-d)" unless options[:pool_dir]
+abort "S3 bucket required (-b)"      unless options[:bucket]
+
+pool_dir = Pathname.new(options[:pool_dir]).expand_path
+abort "Pool directory not found: #{pool_dir}" unless pool_dir.directory?
+
+s3    = Aws::S3::Client.new(region: options[:region])
+batch = Aws::Batch::Client.new(region: options[:region])
+
+# Upload pool data to S3
+data_prefix = "#{options[:s3_prefix]}/data"
+puts "Uploading pool data to s3://#{options[:bucket]}/#{data_prefix}/ ..."
+
+pool_dir.find do |path|
+  next if path.directory?
+  key = "#{data_prefix}/#{path.relative_path_from(pool_dir)}"
+  print "  #{key}\n"
+  s3.put_object(bucket: options[:bucket], key: key, body: path.binread)
+end
+
+# Submit Batch array job
+job_name = "tournament-pool-poss-#{Time.now.strftime('%Y%m%d-%H%M%S')}"
+puts "\nSubmitting #{NUM_BATCHES}-job Batch array as '#{job_name}'..."
+
+resp = batch.submit_job(
+  job_name:         job_name,
+  job_queue:        options[:job_queue],
+  job_definition:   options[:job_definition],
+  array_properties: { size: NUM_BATCHES },
+  container_overrides: {
+    environment: [
+      { name: 'POOL_S3_BUCKET',    value: options[:bucket] },
+      { name: 'POOL_S3_PREFIX',    value: options[:s3_prefix] },
+      { name: 'POOL_NUM_BATCHES',  value: NUM_BATCHES.to_s }
+    ]
+  }
+)
+
+job_id = resp.job_id
+puts "Submitted job ID: #{job_id}"
+puts
+puts "When complete, collect results with:"
+puts "  ruby aws/scripts/aggregate.rb -b #{options[:bucket]} -d #{pool_dir} --prefix #{options[:s3_prefix]}"

--- a/aws/worker.sh
+++ b/aws/worker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+BATCH_INDEX=${AWS_BATCH_JOB_ARRAY_INDEX}
+NUM_BATCHES=${POOL_NUM_BATCHES:-4096}
+BUCKET=${POOL_S3_BUCKET}
+PREFIX=${POOL_S3_PREFIX:-pool}
+
+WORK_DIR=$(mktemp -d)
+trap "rm -rf ${WORK_DIR}" EXIT
+
+echo "Worker ${BATCH_INDEX} of ${NUM_BATCHES} starting..."
+
+aws s3 sync "s3://${BUCKET}/${PREFIX}/data/" "${WORK_DIR}/"
+
+pool -d "${WORK_DIR}" -b "${BATCH_INDEX}" -n "${NUM_BATCHES}" -f bin poss
+
+BIN_FILE="${WORK_DIR}/poss_${BATCH_INDEX}_of_${NUM_BATCHES}.bin"
+aws s3 cp "${BIN_FILE}" "s3://${BUCKET}/${PREFIX}/bins/poss_${BATCH_INDEX}_of_${NUM_BATCHES}.bin"
+
+echo "Worker ${BATCH_INDEX} complete."


### PR DESCRIPTION
## Summary

- Adds `aws/` directory with a complete (untested) implementation for running the `poss` report overnight after Day 1 of Round 1 using AWS Batch
- 4,096 Spot jobs (c6a) cover 2^47 ≈ 140 trillion outcomes in ~4 hours at an estimated cost of ~$280
- Updates main README with corrected compute estimates based on current DFS throughput (2.3M nodes/sec)

## What's included

- `aws/Dockerfile` — builds `pool` binary on Amazon Linux 2023
- `aws/worker.sh` — container entrypoint: syncs pool data from S3, runs `pool -b/-n/-f bin`, uploads `.bin` result
- `aws/Gemfile` + `aws/scripts/submit_jobs.rb` — uploads pool dir to S3, submits 4,096-job Batch array
- `aws/scripts/aggregate.rb` — parallel-downloads all `.bin` files (32 threads), runs `pool -r poss` locally
- `aws/infra/` — Terraform for S3, ECR, Batch compute environment, job queue, job definition, and IAM roles
- `aws/README.md` — setup and usage instructions (includes untested/cost-estimate disclaimer)

## Test plan

- [ ] `terraform plan` in `aws/infra/` with a real AWS account
- [ ] Docker build succeeds: `docker build -f aws/Dockerfile .`
- [ ] End-to-end smoke test against a small pool with a reduced batch count

🤖 Generated with [Claude Code](https://claude.com/claude-code)